### PR TITLE
kPhonetic for U+8411 萑 and U+26F09 𦼉

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -9813,7 +9813,7 @@ U+840C 萌	kPhonetic	903
 U+840D 萍	kPhonetic	1058A
 U+840E 萎	kPhonetic	1425
 U+840F 萏	kPhonetic	421
-U+8411 萑	kPhonetic	216x 285
+U+8411 萑	kPhonetic	285
 U+8413 萓	kPhonetic	1541*
 U+8418 萘	kPhonetic	987
 U+841D 萝	kPhonetic	828
@@ -15149,7 +15149,7 @@ U+26E17 𦸗	kPhonetic	175*
 U+26E1B 𦸛	kPhonetic	51*
 U+26EA3 𦺣	kPhonetic	506*
 U+26EA5 𦺥	kPhonetic	1354*
-U+26F09 𦼉	kPhonetic	216x*
+U+26F09 𦼉	kPhonetic	285*
 U+26F2A 𦼪	kPhonetic	887*
 U+26F2F 𦼯	kPhonetic	307
 U+26F4F 𦽏	kPhonetic	390*


### PR DESCRIPTION
These characters are the only two entries with "x" this field.

The first one, U+8411, is stated in the database documentation to be assigned incorrectly to group 216. If you examine Casey, the pronunciation and definition for this assignment corresponds to U+8549 蕉, which currently has a phonetic group of 216 in the database with no asterisk. It appears there is no incorrect assignment in Casey, just a misprinted character.

The second one, U+26F09, cannot in principle be incorrectly assigned if it doesn't even appear in Casey. The phonetic group has been updated accordingly.

If this pull request is accepted, then the database documentation should be updated as well to remove this descriptor. There does not appear to be any error in the radical-stroke index mapping in Casey: U+8411 萑 points to group 285 only, while U+8549 蕉 points to 216 as expected.