### PR TITLE
kPhonetic for U+6EF6 滶

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -6571,6 +6571,7 @@ U+6EF1 滱	kPhonetic	590
 U+6EF2 滲	kPhonetic	23
 U+6EF3 滳	kPhonetic	1159*
 U+6EF4 滴	kPhonetic	1326
+U+6EF6 滶	kPhonetic	966
 U+6EF7 滷	kPhonetic	822
 U+6EF8 滸	kPhonetic	518
 U+6EF9 滹	kPhonetic	379


### PR DESCRIPTION
This characters is assigned in both the Cantonese (p.209) and Mandarin (p.229) indices to phonetic group 966, but does not not appear in that group. This appears to be a simple oversight. I propose assigning it to this group without an asterisk.