### PR TITLE
kPhonetic for U+4A57 䩗

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -1049,6 +1049,7 @@ U+4A43 䩃	kPhonetic	1030*
 U+4A46 䩆	kPhonetic	10*
 U+4A49 䩉	kPhonetic	386*
 U+4A52 䩒	kPhonetic	1602*
+U+4A57 䩗	kPhonetic	997*
 U+4A59 䩙	kPhonetic	1623*
 U+4A5A 䩚	kPhonetic	1307*
 U+4A5B 䩛	kPhonetic	1059*


### PR DESCRIPTION
This character does not appear in Casey. The database says it has the same pronunciation and meaning as the root phonetic of this group.

This character was pruned from group 1639 in October.