### PR TITLE
Reassignments for group 1491

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -209,7 +209,7 @@ U+3898 㢘	kPhonetic	615
 U+3899 㢙	kPhonetic	576
 U+389A 㢚	kPhonetic	822A*
 U+389F 㢟	kPhonetic	1491*
-U+38A0 㢠	kPhonetic	1491*
+U+38A0 㢠	kPhonetic	742*
 U+38A3 㢣	kPhonetic	627*
 U+38A5 㢥	kPhonetic	1407*
 U+38B6 㢶	kPhonetic	1002*
@@ -4023,7 +4023,7 @@ U+5EF9 廹	kPhonetic	1003
 U+5EFA 建	kPhonetic	620 1491
 U+5EFB 廻	kPhonetic	1464
 U+5EFC 廼	kPhonetic	1112
-U+5EFD 廽	kPhonetic	1491*
+U+5EFD 廽	kPhonetic	1464*
 U+5EFE 廾	kPhonetic	690
 U+5EFF 廿	kPhonetic	1552
 U+5F00 开	kPhonetic	103 488 617
@@ -14377,7 +14377,7 @@ U+22285 𢊅	kPhonetic	286*
 U+2229A 𢊚	kPhonetic	1099*
 U+222B1 𢊱	kPhonetic	1020*
 U+222B2 𢊲	kPhonetic	1120*
-U+2231A 𢌚	kPhonetic	1491*
+U+2231A 𢌚	kPhonetic	1103*
 U+2231C 𢌜	kPhonetic	1345
 U+22341 𢍁	kPhonetic	1512*
 U+2234F 𢍏	kPhonetic	1046*


### PR DESCRIPTION
These characters appear to belong elsewhere. The last addition U+389F 㢟 doesn't really fit group 135 and can stay here for the time being.