### PR TITLE
kPhonetic for U+762A 瘪

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -7742,6 +7742,7 @@ U+7626 瘦	kPhonetic	1143
 U+7627 瘧	kPhonetic	1525
 U+7628 瘨	kPhonetic	63
 U+7629 瘩	kPhonetic	1301
+U+762A 瘪	kPhonetic	1060*
 U+762C 瘬	kPhonetic	111*
 U+762D 瘭	kPhonetic	1066
 U+762F 瘯	kPhonetic	306


### PR DESCRIPTION
This is the simplified form of the root phonetic for group 1060. It could also be included in group 146, but that seems redundant.