### PR TITLE
kPhonetic for U+571D 圝

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -2876,7 +2876,7 @@ U+5716 圖	kPhonetic	1364
 U+5718 團	kPhonetic	1386
 U+571B 圛	kPhonetic	1560
 U+571C 圜	kPhonetic	1419
-U+571D 圝	kPhonetic	833*
+U+571D 圝	kPhonetic	833
 U+571E 圞	kPhonetic	833A
 U+571F 土	kPhonetic	1359
 U+5723 圣	kPhonetic	204 1207


### PR DESCRIPTION
This character appears in Casey. Looks like a typo.