### PR TITLE
kPhonetic for U+5058 偘

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -1671,6 +1671,7 @@ U+5053 偓	kPhonetic	1408
 U+5055 偕	kPhonetic	537
 U+5056 偖	kPhonetic	94*
 U+5057 偗	kPhonetic	1108*
+U+5058 偘	kPhonetic	498* 1021*
 U+505A 做	kPhonetic	753
 U+505B 偛	kPhonetic	41*
 U+505C 停	kPhonetic	1344


### PR DESCRIPTION
One of my dictionaries gives this as an alternate form of U+4F83 侃, although that is not stated in the Unihan database. The other group assignment is straightforward.