### PR TITLE
kPhonetic for U+65BD 施

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -5363,7 +5363,7 @@ U+65B7 斷	kPhonetic	1388
 U+65B8 斸	kPhonetic	1265
 U+65B9 方	kPhonetic	373
 U+65BC 於	kPhonetic	1601
-U+65BD 施	kPhonetic	1168 1471
+U+65BD 施	kPhonetic	1168 1471 1545*
 U+65BE 斾	kPhonetic	357
 U+65BF 斿	kPhonetic	1508
 U+65C1 旁	kPhonetic	373 1081


### PR DESCRIPTION
This character has its own phonetic group, 1168, but also occurs in Casey in 1471, which would appear to be a mistake. Another character, U+5F1B 弛, appears in Casey in both 1471 and 1545, and this latter entry also appears to be a mistake.

This simplest fix is to add this character to 1545 with an asterisk. We could of course return to using the "x" suffix for these two cases, but we need not do that for Unicode 16. Comments?