### PR TITLE
kPhonetic for U+5B6C 孬

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -3541,7 +3541,7 @@ U+5B67 孧	kPhonetic	1507*
 U+5B69 孩	kPhonetic	490
 U+5B6A 孪	kPhonetic	833*
 U+5B6B 孫	kPhonetic	1242
-U+5B6C 孬	kPhonetic	1025
+U+5B6C 孬	kPhonetic	481* 1025
 U+5B70 孰	kPhonetic	746 1263
 U+5B71 孱	kPhonetic	31A 1107
 U+5B73 孳	kPhonetic	132


### PR DESCRIPTION
The pronunciation of this odd character is closer to the first group than the second. Odd choice of assignment by Casey.