### PR TITLE
kPhonetic for U+9D63 鵣

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -14034,6 +14034,7 @@ U+9D5E 鵞	kPhonetic	967
 U+9D5F 鵟	kPhonetic	751*
 U+9D60 鵠	kPhonetic	642
 U+9D61 鵡	kPhonetic	915
+U+9D63 鵣	kPhonetic	768*
 U+9D64 鵤	kPhonetic	647*
 U+9D69 鵩	kPhonetic	402
 U+9D6A 鵪	kPhonetic	1562


### PR DESCRIPTION
This character was originally assigned in #373 to group 309. At the time I was planning to back link group 768 to 309 by adding U+524C 剌 with an asterisk, but this doesn't feel in the spirit of Casey. If he created the separate group 768 for a different phonetic set, I suppose we should follow his lead.