### PR TITLE
kPhonetic for U+53FD 叽

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -2423,6 +2423,7 @@ U+53F8 司	kPhonetic	1169
 U+53F9 叹	kPhonetic	546*
 U+53FB 叻	kPhonetic	801
 U+53FC 叼	kPhonetic	1349
+U+53FD 叽	kPhonetic	596* 598*
 U+5401 吁	kPhonetic	516 1602
 U+5403 吃	kPhonetic	440
 U+5404 各	kPhonetic	646


### PR DESCRIPTION
This character fits group 596, as well as being a simplified form of one in 598.