### PR TITLE
kPhonetic for U+5711 圑

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -3060,12 +3060,12 @@ U+570A 圊	kPhonetic	203
 U+570B 國	kPhonetic	748 1416
 U+570C 圌	kPhonetic	1383
 U+570D 圍	kPhonetic	1433
-U+5711 圑	kPhonetic	269
+U+5711 圑	kPhonetic	381*
 U+5712 園	kPhonetic	1626
 U+5713 圓	kPhonetic	1628
 U+5715 圕	kPhonetic	1235 1364
 U+5716 圖	kPhonetic	1364
-U+5718 團	kPhonetic	1386
+U+5718 團	kPhonetic	269 1386
 U+571B 圛	kPhonetic	1560
 U+571C 圜	kPhonetic	1419
 U+571D 圝	kPhonetic	833


### PR DESCRIPTION
This character does not appear in Casey and is assigned to the wrong group. The correct character is U+5718 團.