### PR TITLE
kPhonetic for U+9CF5 鳵

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -14345,7 +14345,7 @@ U+9CEE 鳮	kPhonetic	427
 U+9CF2 鳲	kPhonetic	1176
 U+9CF3 鳳	kPhonetic	342 408
 U+9CF4 鳴	kPhonetic	904
-U+9CF5 鳵	kPhonetic	982*
+U+9CF5 鳵	kPhonetic	982* 1267*
 U+9CF6 鳶	kPhonetic	1558
 U+9CF7 鳷	kPhonetic	130
 U+9CF8 鳸	kPhonetic	1462


### PR DESCRIPTION
This character was reassigned by me in #264 as part of issue #265 because its sound is closer to the radical than the root phonetic. Thinking in retrospect about how I personally use the data on a daily basis, I would expect to find this character under the root phonetic, so for ease of use I think it should be double assigned. Since a database doesn't have the limitations of a paper book, this change doesn't add much overhead compared to enhancing the user experience.

This sort of double assignment is intended to apply only when there is a strong root phonetic but the sound is still closer to the radical. There are at least a few more cases of this type created by me while proofing additions earlier in the year, as well as existing entries that would follow the same rule.

Before entering any more such double assignments I would like to have feedback on this approach. It could apply in principle to entries already in Casey, again with the idea of making it easier to find characters.