### PR TITLE
kPhonetic for U+635A 捚

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -5711,6 +5711,7 @@ U+6354 捔	kPhonetic	647
 U+6355 捕	kPhonetic	386
 U+6357 捗	kPhonetic	1071*
 U+6358 捘	kPhonetic	313
+U+635A 捚	kPhonetic	1140*
 U+635D 捝	kPhonetic	1392
 U+635E 捞	kPhonetic	821*
 U+6361 捡	kPhonetic	182*


### PR DESCRIPTION
This character does not follow the sound of group 789. Since it is a combination of two radicals, follow the sound.