### PR TITLE
Additions for group 106

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -324,6 +324,7 @@ U+389F 㢟	kPhonetic	1491*
 U+38A0 㢠	kPhonetic	742*
 U+38A3 㢣	kPhonetic	627*
 U+38A5 㢥	kPhonetic	1407*
+U+38A9 㢩	kPhonetic	106*
 U+38B0 㢰	kPhonetic	1038*
 U+38B6 㢶	kPhonetic	1002*
 U+38BB 㢻	kPhonetic	1425*
@@ -348,6 +349,7 @@ U+38F0 㣰	kPhonetic	1186*
 U+38F1 㣱	kPhonetic	16*
 U+38FA 㣺	kPhonetic	1118
 U+38FC 㣼	kPhonetic	1482 1492
+U+38FF 㣿	kPhonetic	106*
 U+3903 㤃	kPhonetic	373*
 U+3904 㤄	kPhonetic	357
 U+3906 㤆	kPhonetic	339*
@@ -914,6 +916,7 @@ U+407B 䁻	kPhonetic	972*
 U+407C 䁼	kPhonetic	875*
 U+407D 䁽	kPhonetic	813*
 U+4081 䂁	kPhonetic	24*
+U+4086 䂆	kPhonetic	106*
 U+408D 䂍	kPhonetic	1072*
 U+4095 䂕	kPhonetic	1400*
 U+40A1 䂡	kPhonetic	1506*
@@ -953,6 +956,7 @@ U+411F 䄟	kPhonetic	297*
 U+4121 䄡	kPhonetic	179*
 U+4128 䄨	kPhonetic	1602*
 U+4129 䄩	kPhonetic	1558*
+U+412A 䄪	kPhonetic	106*
 U+4130 䄰	kPhonetic	951*
 U+4131 䄱	kPhonetic	373*
 U+413A 䄺	kPhonetic	1542
@@ -1629,6 +1633,7 @@ U+4A9C 䪜	kPhonetic	179*
 U+4A9E 䪞	kPhonetic	1109
 U+4AA1 䪡	kPhonetic	139
 U+4AA4 䪤	kPhonetic	338*
+U+4AA8 䪨	kPhonetic	106*
 U+4AA9 䪩	kPhonetic	565*
 U+4AB0 䪰	kPhonetic	1535*
 U+4AB3 䪳	kPhonetic	1443*
@@ -1860,6 +1865,7 @@ U+4D59 䵙	kPhonetic	1365*
 U+4D5A 䵚	kPhonetic	1599*
 U+4D5B 䵛	kPhonetic	619*
 U+4D5C 䵜	kPhonetic	991*
+U+4D60 䵠	kPhonetic	106*
 U+4D62 䵢	kPhonetic	894*
 U+4D63 䵣	kPhonetic	1296*
 U+4D65 䵥	kPhonetic	1188*
@@ -1871,6 +1877,7 @@ U+4D7B 䵻	kPhonetic	1341*
 U+4D7C 䵼	kPhonetic	1341*
 U+4D7E 䵾	kPhonetic	392*
 U+4D81 䶁	kPhonetic	1303*
+U+4D82 䶂	kPhonetic	106*
 U+4D83 䶃	kPhonetic	565*
 U+4D84 䶄	kPhonetic	1058*
 U+4D85 䶅	kPhonetic	646*
@@ -3639,6 +3646,7 @@ U+572D 圭	kPhonetic	699 710
 U+572E 圮	kPhonetic	597
 U+5730 地	kPhonetic	1471
 U+5733 圳	kPhonetic	273
+U+5734 圴	kPhonetic	106*
 U+573B 圻	kPhonetic	571
 U+573C 圼	kPhonetic	981 1501
 U+573E 圾	kPhonetic	581
@@ -4428,7 +4436,7 @@ U+5C22 尢	kPhonetic	1455
 U+5C23 尣	kPhonetic	1455
 U+5C24 尤	kPhonetic	1511
 U+5C25 尥	kPhonetic	106
-U+5C26 尦	kPhonetic	106
+U+5C26 尦	kPhonetic	106*
 U+5C27 尧	kPhonetic	1598
 U+5C28 尨	kPhonetic	856 923 1081A
 U+5C29 尩	kPhonetic	1456
@@ -5030,6 +5038,7 @@ U+5F70 彰	kPhonetic	110
 U+5F71 影	kPhonetic	626
 U+5F72 彲	kPhonetic	772
 U+5F73 彳	kPhonetic	174 435
+U+5F74 彴	kPhonetic	106*
 U+5F77 彷	kPhonetic	373
 U+5F79 役	kPhonetic	174 1557
 U+5F7A 彺	kPhonetic	1456
@@ -5571,6 +5580,7 @@ U+6253 打	kPhonetic	1282 1340
 U+6254 扔	kPhonetic	938
 U+6258 托	kPhonetic	1312
 U+6259 扙	kPhonetic	116*
+U+625A 扚	kPhonetic	106*
 U+625B 扛	kPhonetic	684
 U+625C 扜	kPhonetic	1602*
 U+625E 扞	kPhonetic	653
@@ -6264,6 +6274,7 @@ U+65EC 旬	kPhonetic	318
 U+65ED 旭	kPhonetic	587
 U+65F0 旰	kPhonetic	653
 U+65F1 旱	kPhonetic	502 653
+U+65F3 旳	kPhonetic	106*
 U+65F4 旴	kPhonetic	1602*
 U+65F5 旵	kPhonetic	1178
 U+65F6 时	kPhonetic	149
@@ -8379,6 +8390,7 @@ U+72AF 犯	kPhonetic	345
 U+72B0 犰	kPhonetic	587 1176
 U+72B1 犱	kPhonetic	1627*
 U+72B2 犲	kPhonetic	247
+U+72B3 犳	kPhonetic	106*
 U+72B4 犴	kPhonetic	653
 U+72B5 犵	kPhonetic	440
 U+72B8 犸	kPhonetic	863*
@@ -10510,6 +10522,7 @@ U+7E9C 纜	kPhonetic	765
 U+7EA0 纠	kPhonetic	583*
 U+7EA1 纡	kPhonetic	1602*
 U+7EA4 纤	kPhonetic	183*
+U+7EA6 约	kPhonetic	106*
 U+7EA8 纨	kPhonetic	1627*
 U+7EAB 纫	kPhonetic	1492*
 U+7EAC 纬	kPhonetic	1433*
@@ -10817,6 +10830,7 @@ U+808C 肌	kPhonetic	596
 U+808E 肎	kPhonetic	434
 U+808F 肏	kPhonetic	1498* 1648*
 U+8090 肐	kPhonetic	440
+U+8091 肑	kPhonetic	106*
 U+8092 肒	kPhonetic	1627*
 U+8093 肓	kPhonetic	922
 U+8095 肕	kPhonetic	1492
@@ -11836,6 +11850,7 @@ U+866C 虬	kPhonetic	583 1634A
 U+866E 虮	kPhonetic	598*
 U+866F 虯	kPhonetic	583
 U+8671 虱	kPhonetic	1134
+U+8673 虳	kPhonetic	106*
 U+8675 虵	kPhonetic	1368 1471
 U+8676 虶	kPhonetic	1602*
 U+8677 虷	kPhonetic	653
@@ -12428,6 +12443,7 @@ U+8A04 訄	kPhonetic	587
 U+8A07 訇	kPhonetic	732 1442 1575
 U+8A08 計	kPhonetic	556 1132
 U+8A0A 訊	kPhonetic	1267
+U+8A0B 訋	kPhonetic	106*
 U+8A0C 訌	kPhonetic	684
 U+8A0E 討	kPhonetic	277 1358A
 U+8A0F 訏	kPhonetic	1602
@@ -14242,6 +14258,7 @@ U+9483 钃	kPhonetic	1265
 U+9485 钅	kPhonetic	566
 U+948E 钎	kPhonetic	192*
 U+9490 钐	kPhonetic	1101*
+U+9493 钓	kPhonetic	106*
 U+949B 钛	kPhonetic	1289*
 U+949D 钝	kPhonetic	1385*
 U+94A4 钤	kPhonetic	565*
@@ -15102,6 +15119,7 @@ U+99AC 馬	kPhonetic	863
 U+99AD 馭	kPhonetic	950 1519 1618
 U+99AE 馮	kPhonetic	409 1051
 U+99AF 馯	kPhonetic	653
+U+99B0 馰	kPhonetic	106*
 U+99B1 馱	kPhonetic	1288
 U+99B3 馳	kPhonetic	1471
 U+99B4 馴	kPhonetic	273
@@ -15410,6 +15428,7 @@ U+9B58 魘	kPhonetic	1565A
 U+9B59 魙	kPhonetic	181
 U+9B5A 魚	kPhonetic	1605
 U+9B5F 魟	kPhonetic	684
+U+9B61 魡	kPhonetic	106*
 U+9B67 魧	kPhonetic	660*
 U+9B68 魨	kPhonetic	1385
 U+9B6C 魬	kPhonetic	339
@@ -16163,6 +16182,7 @@ U+20666 𠙦	kPhonetic	1587
 U+2067D 𠙽	kPhonetic	336
 U+20686 𠚆	kPhonetic	5*
 U+2068A 𠚊	kPhonetic	1059*
+U+206AD 𠚭	kPhonetic	106*
 U+206AF 𠚯	kPhonetic	963*
 U+206CA 𠛊	kPhonetic	1184*
 U+206D0 𠛐	kPhonetic	894*
@@ -16282,6 +16302,7 @@ U+20B36 𠬶	kPhonetic	60
 U+20B6F 𠭯	kPhonetic	9*
 U+20B9F 𠮟	kPhonetic	75*
 U+20BA6 𠮦	kPhonetic	219 1353
+U+20BAD 𠮭	kPhonetic	106*
 U+20BB3 𠮳	kPhonetic	1166*
 U+20BB5 𠮵	kPhonetic	1166*
 U+20BBE 𠮾	kPhonetic	963*
@@ -16440,6 +16461,7 @@ U+21627 𡘧	kPhonetic	1071*
 U+21634 𡘴	kPhonetic	1013A*
 U+21681 𡚁	kPhonetic	1013
 U+216A0 𡚠	kPhonetic	372*
+U+216B7 𡚷	kPhonetic	106*
 U+216BC 𡚼	kPhonetic	1184*
 U+216D9 𡛙	kPhonetic	1507*
 U+216DC 𡛜	kPhonetic	1307*
@@ -16619,6 +16641,7 @@ U+2200C 𢀌	kPhonetic	51*
 U+2200D 𢀍	kPhonetic	1653*
 U+22016 𢀖	kPhonetic	623
 U+2201C 𢀜	kPhonetic	684*
+U+22055 𢁕	kPhonetic	106*
 U+22058 𢁘	kPhonetic	1101*
 U+2206E 𢁮	kPhonetic	565*
 U+22071 𢁱	kPhonetic	1594*
@@ -16929,6 +16952,7 @@ U+22EB4 𢺴	kPhonetic	1448*
 U+22EC5 𢻅	kPhonetic	683*
 U+22ED7 𢻗	kPhonetic	41*
 U+22EE7 𢻧	kPhonetic	1264*
+U+22EED 𢻭	kPhonetic	106*
 U+22EF6 𢻶	kPhonetic	565*
 U+22EF9 𢻹	kPhonetic	1030*
 U+22F13 𢼓	kPhonetic	551*
@@ -17099,6 +17123,7 @@ U+23990 𣦐	kPhonetic	656*
 U+23996 𣦖	kPhonetic	1071*
 U+239B5 𣦵	kPhonetic	1285
 U+239BC 𣦼	kPhonetic	29 1285
+U+239C0 𣧀	kPhonetic	106*
 U+239C4 𣧄	kPhonetic	27 273 815
 U+2E9CA 𮧊	kPhonetic	97*
 U+239D7 𣧗	kPhonetic	1511*
@@ -17578,6 +17603,8 @@ U+24FAC 𤾬	kPhonetic	935*
 U+24FAD 𤾭	kPhonetic	1235*
 U+24FB8 𤾸	kPhonetic	1431
 U+24FBA 𤾺	kPhonetic	1294*
+U+24FC8 𤿈	kPhonetic	106*
+U+24FC9 𤿉	kPhonetic	106*
 U+24FCE 𤿎	kPhonetic	1030*
 U+24FD6 𤿖	kPhonetic	931*
 U+24FD7 𤿗	kPhonetic	931*
@@ -17691,6 +17718,7 @@ U+253F2 𥏲	kPhonetic	254*
 U+253F9 𥏹	kPhonetic	637*
 U+25400 𥐀	kPhonetic	1173*
 U+2540A 𥐊	kPhonetic	635*
+U+2541D 𥐝	kPhonetic	106*
 U+2542D 𥐭	kPhonetic	950*
 U+25450 𥑐	kPhonetic	551*
 U+25451 𥑑	kPhonetic	1507*
@@ -17824,6 +17852,7 @@ U+25AB5 𥪵	kPhonetic	41*
 U+25AB9 𥪹	kPhonetic	298*
 U+25AD7 𥫗	kPhonetic	304
 U+25ADD 𥫝	kPhonetic	1558*
+U+25AE9 𥫩	kPhonetic	106*
 U+25AF1 𥫱	kPhonetic	1385*
 U+25AF3 𥫳	kPhonetic	373*
 U+25AF5 𥫵	kPhonetic	1289*
@@ -18000,6 +18029,7 @@ U+26246 𦉆	kPhonetic	13
 U+26259 𦉙	kPhonetic	144*
 U+2625C 𦉜	kPhonetic	179*
 U+26261 𦉡	kPhonetic	1293*
+U+26279 𦉹	kPhonetic	106*
 U+26281 𦊁	kPhonetic	1030*
 U+26282 𦊂	kPhonetic	1461*
 U+26283 𦊃	kPhonetic	565*
@@ -18185,6 +18215,7 @@ U+269E5 𦧥	kPhonetic	1303*
 U+269EC 𦧬	kPhonetic	1400*
 U+269F1 𦧱	kPhonetic	39*
 U+269FB 𦧻	kPhonetic	24*
+U+26A13 𦨓	kPhonetic	106*
 U+26A24 𦨤	kPhonetic	1452*
 U+26A2A 𦨪	kPhonetic	1296*
 U+26A2C 𦨬	kPhonetic	1452*
@@ -18351,6 +18382,7 @@ U+275CD 𧗍	kPhonetic	645*
 U+275E6 𧗦	kPhonetic	103*
 U+275F4 𧗴	kPhonetic	1660*
 U+275FF 𧗿	kPhonetic	1278*
+U+27611 𧘑	kPhonetic	106*
 U+2761C 𧘜	kPhonetic	192*
 U+27622 𧘢	kPhonetic	1461*
 U+2762E 𧘮	kPhonetic	523*
@@ -18563,6 +18595,7 @@ U+27E6F 𧹯	kPhonetic	549*
 U+27E70 𧹰	kPhonetic	101*
 U+27E7A 𧹺	kPhonetic	297*
 U+27E89 𧺉	kPhonetic	220
+U+27E95 𧺕	kPhonetic	106*
 U+27EA3 𧺣	kPhonetic	329*
 U+27EB2 𧺲	kPhonetic	1030*
 U+27EB4 𧺴	kPhonetic	950*
@@ -19219,6 +19252,7 @@ U+2956F 𩕯	kPhonetic	1149*
 U+29571 𩕱	kPhonetic	935*
 U+2958C 𩖌	kPhonetic	24*
 U+29597 𩖗	kPhonetic	567*
+U+2959A 𩖚	kPhonetic	106*
 U+295A4 𩖤	kPhonetic	1385*
 U+295A6 𩖦	kPhonetic	565*
 U+295C2 𩗂	kPhonetic	931*
@@ -19252,6 +19286,7 @@ U+29647 𩙇	kPhonetic	298*
 U+29652 𩙒	kPhonetic	1062*
 U+29667 𩙧	kPhonetic	1149*
 U+29679 𩙹	kPhonetic	410*
+U+29688 𩚈	kPhonetic	106*
 U+29695 𩚕	kPhonetic	565*
 U+2969C 𩚜	kPhonetic	565*
 U+296A6 𩚦	kPhonetic	215*
@@ -19430,6 +19465,7 @@ U+29C19 𩰙	kPhonetic	1497*
 U+29C34 𩰴	kPhonetic	1537*
 U+29C43 𩱃	kPhonetic	620*
 U+29C7B 𩱻	kPhonetic	711*
+U+29C83 𩲃	kPhonetic	106*
 U+29C8B 𩲋	kPhonetic	660*
 U+29C8C 𩲌	kPhonetic	373*
 U+29C8D 𩲍	kPhonetic	964*
@@ -19481,6 +19517,7 @@ U+29F7D 𩽽	kPhonetic	17*
 U+29F81 𩾁	kPhonetic	592*
 U+29F82 𩾂	kPhonetic	1149*
 U+29F8C 𩾌	kPhonetic	504*
+U+29FA1 𩾡	kPhonetic	106*
 U+29FA2 𩾢	kPhonetic	1558*
 U+29FB8 𩾸	kPhonetic	58*
 U+29FD3 𩿓	kPhonetic	982*
@@ -19761,6 +19798,7 @@ U+2AA47 𪩇	kPhonetic	780*
 U+2AA53 𪩓	kPhonetic	1410
 U+2AA78 𪩸	kPhonetic	1020*
 U+2AA7F 𪩿	kPhonetic	1293*
+U+2AA8A 𪪊	kPhonetic	106*
 U+2AA9D 𪪝	kPhonetic	1653*
 U+2AAA2 𪪢	kPhonetic	547*
 U+2AAA4 𪪤	kPhonetic	1296*
@@ -19816,6 +19854,7 @@ U+2AF24 𪼤	kPhonetic	179*
 U+2AF58 𪽘	kPhonetic	850*
 U+2AF6C 𪽬	kPhonetic	894*
 U+2AF6E 𪽮	kPhonetic	820A*
+U+2AFA0 𪾠	kPhonetic	106*
 U+2AFA6 𪾦	kPhonetic	820A*
 U+2AFDE 𪿞	kPhonetic	1149*
 U+2B01E 𫀞	kPhonetic	254*
@@ -20078,6 +20117,7 @@ U+2C364 𬍤	kPhonetic	62*
 U+2C3A7 𬎧	kPhonetic	329*
 U+2C3AC 𬎬	kPhonetic	1293*
 U+2C3B1 𬎱	kPhonetic	245*
+U+2C3C0 𬏀	kPhonetic	106*
 U+2C3E6 𬏦	kPhonetic	346*
 U+2C3ED 𬏭	kPhonetic	101*
 U+2C3F7 𬏷	kPhonetic	1020*
@@ -20208,6 +20248,7 @@ U+2CD28 𬴨	kPhonetic	1598*
 U+2CD6A 𬵪	kPhonetic	1437*
 U+2CD6C 𬵬	kPhonetic	423*
 U+2CD73 𬵳	kPhonetic	934*
+U+2CD84 𬶄	kPhonetic	106*
 U+2CD89 𬶉	kPhonetic	950*
 U+2CD94 𬶔	kPhonetic	642*
 U+2CD9B 𬶛	kPhonetic	1294*
@@ -20258,6 +20299,7 @@ U+2D58D 𭖍	kPhonetic	97*
 U+2D5E1 𭗡	kPhonetic	645*
 U+2D5EC 𭗬	kPhonetic	1573*
 U+2D5EE 𭗮	kPhonetic	1293*
+U+2D605 𭘅	kPhonetic	106*
 U+2D614 𭘔	kPhonetic	950*
 U+2D615 𭘕	kPhonetic	894*
 U+2D65D 𭙝	kPhonetic	927*
@@ -20453,9 +20495,11 @@ U+300FF 𰃿	kPhonetic	1395*
 U+30100 𰄀	kPhonetic	763*
 U+30101 𰄁	kPhonetic	23*
 U+3010A 𰄊	kPhonetic	39*
+U+3011B 𰄛	kPhonetic	106*
 U+3011E 𰄞	kPhonetic	269*
 U+30136 𰄶	kPhonetic	23*
 U+3014A 𰅊	kPhonetic	1296*
+U+3015D 𰅝	kPhonetic	106*
 U+30165 𰅥	kPhonetic	1395*
 U+30166 𰅦	kPhonetic	1294*
 U+30168 𰅨	kPhonetic	21*
@@ -20667,6 +20711,7 @@ U+30DF6 𰷶	kPhonetic	636*
 U+30DFA 𰷺	kPhonetic	198*
 U+30E19 𰸙	kPhonetic	23*
 U+30E24 𰸤	kPhonetic	24*
+U+30E4B 𰹋	kPhonetic	106*
 U+30E79 𰹹	kPhonetic	215*
 U+30E7C 𰹼	kPhonetic	185*
 U+30E83 𰺃	kPhonetic	1390*
@@ -20880,6 +20925,7 @@ U+32102 𲄂	kPhonetic	410*
 U+3210C 𲄌	kPhonetic	934*
 U+32120 𲄠	kPhonetic	101*
 U+32124 𲄤	kPhonetic	203*
+U+3218F 𲆏	kPhonetic	106*
 U+321A8 𲆨	kPhonetic	950*
 U+321BC 𲆼	kPhonetic	1264*
 U+321EC 𲇬	kPhonetic	1293*


### PR DESCRIPTION
These characters do not appear in Casey.

Oddly enough the root phonetic here appears in a small group 1010 as well, although here it is marked with the double x for importance. Why this second group exists is not clear to me, but it seems prudent for the additions to go into the larger group.

U+5C26 尦 appears to be a variant of U+5C25 尥, but it does not appear in Casey.