### PR TITLE
kPhonetic for U+4E1F 丟

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -1944,6 +1944,7 @@ U+4E1B 丛	kPhonetic	295
 U+4E1C 东	kPhonetic	1403
 U+4E1D 丝	kPhonetic	1170*
 U+4E1E 丞	kPhonetic	1210
+U+4E1F 丟	kPhonetic	1350*
 U+4E21 両	kPhonetic	799
 U+4E22 丢	kPhonetic	519 1350
 U+4E23 丣	kPhonetic	783 870


### PR DESCRIPTION
The Unihan database describes this as a semantic variant of U+4E22 丢, but it has the same pronunciation and meaning. No better place than the same group.