### PR TITLE
kPhonetic for U+8EE2 転

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -13324,6 +13324,7 @@ U+8EDC 軜	kPhonetic	986
 U+8EDD 軝	kPhonetic	1184
 U+8EDF 軟	kPhonetic	467 1631
 U+8EE1 軡	kPhonetic	565*
+U+8EE2 転	kPhonetic	269*
 U+8EE4 軤	kPhonetic	389*
 U+8EE5 軥	kPhonetic	673
 U+8EE6 軦	kPhonetic	474


### PR DESCRIPTION
This character is a Japanese simplification of U+8F49 轉, although that information is not captured in the Unihan database. Is there a plan for specifying Japanese simplifications apart from Chinese simplifications?