### PR TITLE
Replace tab wih space for U+2E7C2

### DIFF
--- a/kPhonetic.txt
+++ b/kPhonetic.txt
@@ -22007,7 +22007,7 @@ U+2E777 𮝷	kPhonetic	1020*
 U+2E779 𮝹	kPhonetic	1419*
 U+2E7A2 𮞢	kPhonetic	1167*
 U+2E7A4 𮞤	kPhonetic	976*
-U+2E7C2	𮟂	kPhonetic	628*
+U+2E7C2 𮟂	kPhonetic	628*
 U+2E7F0 𮟰	kPhonetic	19*
 U+2E81E 𮠞	kPhonetic	254*
 U+2E822 𮠢	kPhonetic	931*


### PR DESCRIPTION
Andrew West's IDS file contains tabs before characters, which I normally remove manually. This overlooked tab generates an error in code on my computer.

Are you seeing any code errors on your end, or would they only show up if you regenerated the entire file?